### PR TITLE
fix: clean up supportedBackend

### DIFF
--- a/valkeyrie.go
+++ b/valkeyrie.go
@@ -12,10 +12,8 @@ import (
 // Initialize creates a new Store object, initializing the client.
 type Initialize func(endpoints []string, options *store.Config) (store.Store, error)
 
-var (
-	// Backend initializers.
-	initializers = make(map[store.Backend]Initialize)
-)
+// Backend initializers.
+var initializers = make(map[store.Backend]Initialize)
 
 // NewStore creates an instance of store.
 func NewStore(backend store.Backend, endpoints []string, options *store.Config) (store.Store, error) {

--- a/valkeyrie.go
+++ b/valkeyrie.go
@@ -10,32 +10,34 @@ import (
 )
 
 // Initialize creates a new Store object, initializing the client.
-type Initialize func(addrs []string, options *store.Config) (store.Store, error)
+type Initialize func(endpoints []string, options *store.Config) (store.Store, error)
 
 var (
 	// Backend initializers.
 	initializers = make(map[store.Backend]Initialize)
-
-	supportedBackend = func() string {
-		keys := make([]string, 0, len(initializers))
-		for k := range initializers {
-			keys = append(keys, string(k))
-		}
-		sort.Strings(keys)
-		return strings.Join(keys, ", ")
-	}()
 )
 
 // NewStore creates an instance of store.
-func NewStore(backend store.Backend, addrs []string, options *store.Config) (store.Store, error) {
+func NewStore(backend store.Backend, endpoints []string, options *store.Config) (store.Store, error) {
 	if init, exists := initializers[backend]; exists {
-		return init(addrs, options)
+		return init(endpoints, options)
 	}
 
-	return nil, fmt.Errorf("%w %s", store.ErrBackendNotSupported, supportedBackend)
+	return nil, fmt.Errorf("%w %s", store.ErrBackendNotSupported, supportedBackend())
 }
 
 // AddStore adds a new store backend to valkeyrie.
 func AddStore(backend store.Backend, init Initialize) {
 	initializers[backend] = init
+}
+
+// supportedBackend returns a comma separated list of all available stores in initializers.
+func supportedBackend() string {
+	keys := make([]string, 0, len(initializers))
+	for k := range initializers {
+		keys = append(keys, string(k))
+	}
+
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
 }

--- a/valkeyrie_test.go
+++ b/valkeyrie_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kvtools/valkeyrie/store"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewStoreUnsupported(t *testing.T) {
@@ -21,4 +22,48 @@ func TestNewStoreUnsupported(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, kv)
 	assert.Equal(t, "Backend storage not supported yet, please choose one of ", err.Error())
+}
+
+func TestListSupportedBackends(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		stores []string
+		expect string
+	}{
+		{
+			desc: "no store",
+		},
+		{
+			desc:   "one store",
+			stores: []string{"foo"},
+			expect: "foo",
+		},
+		{
+			desc:   "two unsorted stores",
+			stores: []string{"foo", "bar"},
+			expect: "bar, foo",
+		},
+		{
+			desc:   "two sorted stores",
+			stores: []string{"bar", "foo"},
+			expect: "bar, foo",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			t.Cleanup(func() { initializers = make(map[store.Backend]Initialize) })
+
+			for _, s := range test.stores {
+				AddStore(store.Backend(s), func(_ []string, _ *store.Config) (store.Store, error) { return nil, nil })
+
+				kv, err := NewStore(store.Backend(s), nil, nil)
+				require.NoError(t, err)
+				require.Nil(t, kv) // AddStore return nil
+			}
+			assert.Equal(t, test.expect, supportedBackend())
+		})
+	}
 }


### PR DESCRIPTION
This PR allows getting a properly formatted error when using stores.

When registering all currently available store, the error when creating a new unsupported store will be:
```
Backend storage not supported yet, please choose one of boltdb, consul, dynamodb, etcd, etcdv3, redis, zk
```

instead of:

```
Backend storage not supported yet, please choose one of
```