### PR TITLE
feat: support TLS configuration for Redis backend

### DIFF
--- a/store/redis/redis_test.go
+++ b/store/redis/redis_test.go
@@ -22,7 +22,7 @@ func makeRedisClient(t *testing.T) store.Store {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	kv := newRedis(ctx, []string{client}, "", nil)
+	kv := newRedis(ctx, []string{client}, nil, "", nil)
 
 	// NOTE: please turn on redis's notification
 	// before you using watch/watchtree/lock related features.


### PR DESCRIPTION
## Motivation

This pull request adds the support of the TLS configuration for the Redis backend. As explained in the linked issue, the TLS configuration is already supported by the client library `github.com/go-redis/redis/v8`.

Fixes #72